### PR TITLE
Add some FK indexes

### DIFF
--- a/schema/sql/heimdall.sql
+++ b/schema/sql/heimdall.sql
@@ -54,6 +54,7 @@ CREATE TABLE object_acl_group(
        permission auth_permission NOT NULL,
        PRIMARY KEY (target, authorizee, permission)
 );
+CREATE INDEX object_acl_group_authorizee ON object_acl_group(authorizee);
 
 CREATE TABLE object_acl_actor(
        target bigint NOT NULL REFERENCES auth_object(id) ON UPDATE CASCADE ON DELETE CASCADE,
@@ -61,6 +62,7 @@ CREATE TABLE object_acl_actor(
        permission auth_permission NOT NULL,
        PRIMARY KEY (target, authorizee, permission)
 );
+CREATE INDEX object_acl_actor_authorizee ON object_acl_actor(authorizee);
 
 CREATE TABLE actor_acl_group(
        target bigint NOT NULL REFERENCES auth_actor(id) ON UPDATE CASCADE ON DELETE CASCADE,
@@ -68,6 +70,7 @@ CREATE TABLE actor_acl_group(
        permission auth_permission NOT NULL,
        PRIMARY KEY (target, authorizee, permission)
 );
+CREATE INDEX actor_acl_group_authorizee ON actor_acl_group(authorizee);
 
 CREATE TABLE actor_acl_actor(
        target bigint NOT NULL REFERENCES auth_actor(id) ON UPDATE CASCADE ON DELETE CASCADE,
@@ -75,6 +78,7 @@ CREATE TABLE actor_acl_actor(
        permission auth_permission NOT NULL,
        PRIMARY KEY (target, authorizee, permission)
 );
+CREATE INDEX actor_acl_actor_authorizee ON actor_acl_actor(authorizee);
 
 CREATE TABLE group_acl_group(
        target bigint NOT NULL REFERENCES auth_group(id) ON UPDATE CASCADE ON DELETE CASCADE,
@@ -82,6 +86,7 @@ CREATE TABLE group_acl_group(
        permission auth_permission NOT NULL,
        PRIMARY KEY (target, authorizee, permission)
 );
+CREATE INDEX group_acl_group_authorizee ON group_acl_group(authorizee);
 
 CREATE TABLE group_acl_actor(
        target bigint NOT NULL REFERENCES auth_group(id) ON UPDATE CASCADE ON DELETE CASCADE,
@@ -89,6 +94,7 @@ CREATE TABLE group_acl_actor(
        permission auth_permission NOT NULL,
        PRIMARY KEY (target, authorizee, permission)
 );
+CREATE INDEX group_acl_actor_authorizee ON group_acl_actor(authorizee);
 
 CREATE TABLE container_acl_group(
        target bigint NOT NULL REFERENCES container(id) ON UPDATE CASCADE ON DELETE CASCADE,
@@ -96,6 +102,7 @@ CREATE TABLE container_acl_group(
        permission auth_permission NOT NULL,
        PRIMARY KEY (target, authorizee, permission)
 );
+CREATE INDEX container_acl_group_authorizee ON container_acl_group(authorizee);
 
 CREATE TABLE container_acl_actor(
        target bigint NOT NULL REFERENCES container(id) ON UPDATE CASCADE ON DELETE CASCADE,
@@ -103,6 +110,7 @@ CREATE TABLE container_acl_actor(
        permission auth_permission NOT NULL,
        PRIMARY KEY (target, authorizee, permission)
 );
+CREATE INDEX container_acl_actor_authorizee ON container_acl_actor(authorizee);
 
 -- Manage the group hierarchies
 
@@ -116,12 +124,14 @@ CREATE TABLE group_group_relations(
        -- check
        CONSTRAINT no_trivial_cycles CHECK(parent != child)
 );
+CREATE INDEX group_group_relations_child ON group_group_relations(child);
 
 CREATE TABLE group_actor_relations(
        parent bigint REFERENCES auth_group(id) ON UPDATE CASCADE ON DELETE CASCADE,
        child bigint REFERENCES auth_actor(id) ON UPDATE CASCADE ON DELETE CASCADE,
        PRIMARY KEY (parent, child)
 );
+CREATE INDEX group_actor_relations_child ON group_actor_relations(child);
 
 CREATE OR REPLACE FUNCTION forbid_group_cycles()
 RETURNS TRIGGER

--- a/schema/t/schema_test.pg
+++ b/schema/t/schema_test.pg
@@ -95,5 +95,36 @@ SELECT fk_ok('container_acl_actor', 'authorizee', 'auth_actor', 'id');
 SELECT fk_ok('container_acl_group', 'target', 'container', 'id');
 SELECT fk_ok('container_acl_group', 'authorizee', 'auth_group', 'id');
 
+\set schema quote_ident('public')
+
+CREATE OR REPLACE FUNCTION opscode.has_index(p_table_schema NAME, p_table_name NAME, p_index_name NAME, p_indexed_columns TEXT[])
+RETURNS TEXT LANGUAGE SQL
+AS $$
+   SELECT has_index($1, $2, $3, $4, 'Columns ' || $1 || '.' || $2 || '(' || array_to_string($4, ', ') || ') should be indexed by index "' || $3 || '"' );
+$$;
+
+CREATE OR REPLACE FUNCTION opscode.has_index(p_table_schema NAME, p_table_name NAME, p_index_name NAME, p_indexed_column TEXT)
+RETURNS TEXT LANGUAGE SQL
+AS $$
+   SELECT opscode.has_index($1, $2, $3, ARRAY[$4]);
+$$;
+
+-- Indexes!
+SELECT opscode.has_index(:schema, 'object_acl_actor', 'object_acl_actor_authorizee', 'authorizee');
+SELECT opscode.has_index(:schema, 'object_acl_group', 'object_acl_group_authorizee', 'authorizee');
+
+SELECT opscode.has_index(:schema, 'group_acl_actor', 'group_acl_actor_authorizee', 'authorizee');
+SELECT opscode.has_index(:schema, 'group_acl_group', 'group_acl_group_authorizee', 'authorizee');
+
+SELECT opscode.has_index(:schema, 'actor_acl_actor', 'actor_acl_actor_authorizee', 'authorizee');
+SELECT opscode.has_index(:schema, 'actor_acl_group', 'actor_acl_group_authorizee', 'authorizee');
+
+SELECT opscode.has_index(:schema, 'container_acl_actor', 'container_acl_actor_authorizee', 'authorizee');
+SELECT opscode.has_index(:schema, 'container_acl_group', 'container_acl_group_authorizee', 'authorizee');
+
+SELECT opscode.has_index(:schema, 'group_group_relations', 'group_group_relations_child', 'child');
+SELECT opscode.has_index(:schema, 'group_actor_relations', 'group_actor_relations_child', 'child');
+
+
 SELECT finish();
 ROLLBACK;


### PR DESCRIPTION
We're only adding indexes for the second half of either a
target/authorizee or a parent/child pair, since the first half is
already effectively indexed by the primary key uniqueness index.
