### PR TITLE
Add 'deep' status check.

### DIFF
--- a/apps/bifrost/src/bifrost_db.erl
+++ b/apps/bifrost/src/bifrost_db.erl
@@ -5,7 +5,8 @@
 
 -include("bifrost.hrl").
 
--export([acl_membership/4,
+-export([ping/0,
+         acl_membership/4,
          add_to_group/3,
          create/3,
          delete/2,
@@ -16,6 +17,12 @@
          remove_from_group/3,
          statements/0,
          update_acl/5]).
+
+ping() ->
+    case select(ping, [], first_as_scalar, [ping]) of
+        {ok, <<"pong">>} -> ok;
+        {error, Reason} -> {error, Reason}
+    end.
 
 translate(<<"OC001">>) -> group_cycle;
 translate(Code) -> sqerl_pgsql_errors:translate_code(Code).

--- a/apps/bifrost/src/bifrost_wm_status_resource.erl
+++ b/apps/bifrost/src/bifrost_wm_status_resource.erl
@@ -20,4 +20,10 @@ content_types_provided(Req, State) ->
     {[{"application/json", to_json}], Req, State}.
 
 to_json(Req, State) ->
-    {<<"{\"status\": \"ok\"}">>, Req, State}.
+    case bifrost_db:ping() of
+        ok ->
+            {<<"{\"status\": \"ok\"}">>, Req, State};
+        {error, Reason} ->
+            lager:error(io_lib:format("status check: ~999p~n", [Reason])),
+            {{halt, 500}, Req, State}
+    end.


### PR DESCRIPTION
Status endpoint calls 'ping' op on DB to make sure it's good.

Passes pedant tests.
