### PR TITLE
Make Splunk Happy

### DIFF
--- a/apps/bifrost/src/bifrost_request_logger.erl
+++ b/apps/bifrost/src/bifrost_request_logger.erl
@@ -61,10 +61,11 @@ generate_msg(#wm_log_data{response_code = ResponseCode,
     ReqId = note(reqid, Notes),
     RequestorId = note(requestor_id, Notes),
     CreatedAuthzId = note(created_authz_id, Notes),
-    PerfStats = case note(perf_stats, Notes) of
+    RawPerfStats = case note(perf_stats, Notes) of
                     undefined -> [];
                     Stats -> Stats
                 end,
+    PerfStats = filter_perf_stats(ResponseCode, RawPerfStats),
 
     %% We'll always output information in the log for these fields,
     %% even if their value is 'undefined'.  These are key fields for
@@ -87,6 +88,17 @@ generate_msg(#wm_log_data{response_code = ResponseCode,
                                ]),
 
     log_line(FinalFields).
+
+%% @doc To stay in Splunk's good graces, we'll only add the total
+%% request time for 200 responses, and keep all other performance
+%% stats for all other responses.
+%%
+%% (200 is the overwhelming majority of the output of the entire
+%% Bifrost API).
+filter_perf_stats(200, RawPerfStats) ->
+    [ {K,V} || {K,V} <- RawPerfStats, K =:= req_time ];
+filter_perf_stats(_, RawPerfStats) ->
+    RawPerfStats.
 
 emit_log(ResponseCode, Msg) when ResponseCode >= 500 ->
     lager:error(Msg);


### PR DESCRIPTION
Here's a stab at reducing Bifrost's logging verbosity.

For the record, here's a typical log line that we currently emit (newlines added for readability; in reality, it's all one line)

```
2013-05-21 18:15:54.291 [info] <0.152.0>@bifrost_request_logger:emit_log:97
status=200;
method=GET; path=/objects/0a1ec89d09fa90d5fe7b2749944bd198/acl/read/actors/c2fe941bb5af8ab68135a7340a9d433a;
module=bifrost_wm_acl_member_resource; 
reqid=8ZYFR6noExK7TUdwxHHIbA==; 
requestor_id=c2fe941bb5af8ab68135a7340a9d433a; 
req_time=5; 
rdbms.bifrost_db.has_permission_time=3; 
rdbms.bifrost_db.has_permission_count=1;
rdbms.bifrost_db.exists_time=1; 
rdbms.bifrost_db.exists_count=1; 
```

This branch would remove the `reqid` and `module` fields from ALL lines, and remove all the stats_hero stats _except_ req_time for 200 responses.  All other response statuses (201, 404, 500, etc.) would retain all stats_hero information.

cc: @seth @kevsmith @jkeiser @langloisjp @doubt72 @igarrison
