### PR TITLE
Lock lager to 2.0.0 tag

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
  [
   %% lager has to come first since we use its parse transform
   {lager, ".*",
-   {git, "https://github.com/basho/lager.git", {branch, "master"}}},
+   {git, "https://github.com/basho/lager.git", {tag, "2.0.0"}}},
   {eper, ".*",
    {git, "git://github.com/massemanet/eper.git", {branch, "master"}}},
   {jiffy, ".*",


### PR DESCRIPTION
We were floating on master, which actually meant that we had shifted from the 1.2.2 release to 2.0.0.
