### PR TITLE
OC-7999: Initial stab at more granular metrics

### DIFF
--- a/apps/bifrost/src/bifrost_wm_base.erl
+++ b/apps/bifrost/src/bifrost_wm_base.erl
@@ -153,10 +153,13 @@ new_request_id() ->
 
 spawn_stats_hero_worker(Req, #base_state{reqid=ReqId,
                                          request_type=RequestType,
+                                         module=Module,
                                          metrics_config=MetricsConfig}) ->
-
-    %% TODO: stats_hero:as_bin/1 should probably handle this, right?
-    RequestLabel = erlang:atom_to_binary(RequestType, utf8),
+    %% Add the module and request type as a two-part label to allow us
+    %% more fine-grained graphing capabilities.  Many modules handle
+    %% multiple kinds of requests, so without this change, we end up
+    %% obscuring quite a bit.
+    RequestLabel = erlang:atom_to_list(Module) ++ "." ++ erlang:atom_to_list(RequestType),
 
     Config = [{request_id, ReqId},
 


### PR DESCRIPTION
This is just to get some initial feedback.

Basically, this adds some extra configuration at the beginning of the Webmachine request that indicates what kind of action is being performed.  This "action" pretty much maps to the underlying resource module that handles the request, though I tried to use a more descriptive name.  This "action" then gets incorporated into the metric label.

```
actor_acl_manipulation        => GET, PUT, DELETE /actors/<actor>/acl/<action>
actor_acl_retrieval           => GET /actors/<actor>/acl
actor_auth_check              => GET /actors/<actor>/acl/<action>/actors/<member>
actor_create                  => POST /actors
actor_entity_manipulation     => GET, DELETE /actors/<actor>

container_acl_manipulation    => GET, PUT, DELETE /containers/<container>/acl/<action>
container_acl_retrieval       => GET /containers/<container>/acl
container_auth_check          => GET /containers/<container>/acl/<action>/actors/<member>
container_create              => POST /containers
container_entity_manipulation => GET, DELETE /containers/<container>

group_acl_manipulation        => GET, PUT, DELETE /groups/<group>/acl/<action>
group_acl_retrieval           => GET /groups/<group>/acl
group_auth_check              => GET /groups/<group>/acl/<action>/actors/<member>
group_create                  => POST /groups
group_entity_manipulation     => GET, DELETE /groups/<group>
group_membership              => PUT /groups/<group>/{groups,actors}/<member>

object_acl_manipulation       => GET, PUT, DELETE /objects/<object>/acl/<action>
object_acl_retrieval          => GET /objects/<object>/acl
object_auth_check             => GET /objects/<object>/acl/<action>/actors/<member>
object_create                 => POST /objects
object_entity_manipulation    => GET, DELETE /objects/<object>
```

Currently "actor_membership" does not exist, since we're just concatenating 'request_type' and 'action'.  Thus PUT `/groups/<group>/groups/<member>` and PUT `/groups/<group>/actors/<member>` fall into the same bucket.

Obviously, the current GDash graphs will need to be tweaked ever so slightly:
![screenshot_5_28_13_4_14_pm](https://f.cloud.github.com/assets/207178/575286/ef0b81f8-c7d9-11e2-9b65-1e932d33073c.png)
