### PR TITLE
Use set difference to compute bulk auth unauthorized IDs

### DIFF
--- a/apps/bifrost/src/bifrost_wm_bulk_resource.erl
+++ b/apps/bifrost/src/bifrost_wm_bulk_resource.erl
@@ -35,13 +35,13 @@ process_post(Req, State) ->
         {ReqId, Permission, Type, Collection} = parse_body(Body),
         case ?SH_TIME(ReqId, bifrost_db, bulk_permission,
                       (ReqId, Collection, Permission, Type)) of
-            List when is_list(List) ->
-                Excluded = lists:filter(fun(X) -> not lists:member(X, List) end,
-                                        Collection),
-                case Excluded of
+            Authorized when is_list(Authorized) ->
                 %% The query above returns which of the supplied targets in the
                 %% parsed collection have permission, but we need to return the
                 %% opposite, so we do this:
+                Unauthorized = sets:to_list(sets:subtract(sets:from_list(Collection),
+                                                          sets:from_list(Authorized))),
+                case Unauthorized of
                     [] ->
                         % If we don't set a body here (or anywhere else, of course,
                         % but that shouldn't happen anyway), web machine should


### PR DESCRIPTION
This'll be faster than the `lists:filter/2` approach.

The only caveat is that the list that is returned currently has no guaranteed order (since it's coming from `sets:to_list/1`.  The Pedant tests still pass with this change in place, and I don't think that a defined order is required, in any event.

cc: @doubt72, @langloisjp, @jkeiser 
