### PR TITLE
Use sqerl master branch

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
   {mixer, ".*",
    {git, "git://github.com/opscode/mixer.git", {tag, "0.1.1"}}},
   {sqerl, ".*",
-   {git, "git://github.com/opscode/sqerl.git", {branch, "jpl/surface_pg_error_code"}}},
+   {git, "git://github.com/opscode/sqerl.git", {branch, "master"}}},
   {stats_hero, ".*",
    {git, "git://github.com/opscode/stats_hero.git", {branch, "master"}}},
   {webmachine, ".*",


### PR DESCRIPTION
This has our error-mapping code merged in, and also picks up an update
to the epgsql driver that treats Postgres arrays correctly.

Tested locally with Pedant.
