### PR TITLE
Of/bulk bifrost delete

### DIFF
--- a/apps/bifrost/priv/dispatch.conf
+++ b/apps/bifrost/priv/dispatch.conf
@@ -26,6 +26,7 @@
 
 %% POST for bulk requests
 {["bulk"], bifrost_wm_bulk_resource, []}.
+{["bulk", "delete"], bifrost_wm_bulk_delete_resource, []}.
 
 %% GET and DELETE of existing entities
 {["actors", id], bifrost_wm_named_resources, [{request_type, actor}]}.

--- a/apps/bifrost/priv/dispatch.conf
+++ b/apps/bifrost/priv/dispatch.conf
@@ -26,7 +26,7 @@
 
 %% POST for bulk requests
 {["bulk"], bifrost_wm_bulk_resource, []}.
-{["bulk", "delete"], bifrost_wm_bulk_delete_resource, []}.
+{["bulk", "_delete"], bifrost_wm_bulk_delete_resource, []}.
 
 %% GET and DELETE of existing entities
 {["actors", id], bifrost_wm_named_resources, [{request_type, actor}]}.

--- a/apps/bifrost/priv/pgsql_statements.config
+++ b/apps/bifrost/priv/pgsql_statements.config
@@ -117,6 +117,14 @@
  <<"SELECT actor_has_bulk_permission_on AS authz_id
     FROM actor_has_bulk_permission_on($1, $2, $3, $4)">>}.
 
+%% Deleting all actors in list
+{bulk_delete_actor,
+ <<"DELETE FROM auth_actor WHERE authz_id = ANY($1)">>}.
+
+%% Deleting all groups in list
+{bulk_delete_group,
+  <<"DELETE FROM auth_group WHERE authz_id = ANY($1)">>}.
+
 %% Checking to see if actors have specific access on an authz entity; function
 %% will also accept 'any' for testing against any permission
 {actor_has_permission_on,

--- a/apps/bifrost/src/bifrost_db.erl
+++ b/apps/bifrost/src/bifrost_db.erl
@@ -9,6 +9,7 @@
          acl_membership/4,
          add_to_group/3,
          bulk_permission/4,
+         bulk_delete/2,
          create/3,
          delete/2,
          delete_acl/3,
@@ -153,6 +154,21 @@ bulk_permission(ActorId, Targets, Perm, TargetType) ->
         {error, Error} ->
             {error, Error}
     end.
+
+bulk_delete_query(actor) ->
+    bulk_delete_actor;
+bulk_delete_query(group) ->
+    bulk_delete_group.
+
+bulk_delete(AuthzIds, Type) ->
+    DeleteStatement = bulk_delete_query(Type),
+    case sqerl:statement(DeleteStatement, [AuthzIds], count) of
+        {ok, N} when is_integer(N) ->
+            N;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
 
 -spec has_permission(auth_type(), auth_id(), auth_id(), permission() | any) ->
                             boolean() | {error, _}.

--- a/apps/bifrost/src/bifrost_wm_bulk_delete_resource.erl
+++ b/apps/bifrost/src/bifrost_wm_bulk_delete_resource.erl
@@ -6,18 +6,11 @@
 -mixin([{bifrost_wm_base, [create_path/2]}]).
 
 -export([
-         process_post/2,
-         post_is_create/2
+         process_post/2
         ]).
 
 init(Config) ->
     bifrost_wm_base:init(?MODULE, Config).
-
-post_is_create(Req, State) ->
-    % We're not creating anything (for a change), just processing information, so
-    % we want to return 200's instead of 201's here; also, instead of from_json, we'll
-    % be using process_post below
-    {false, Req, State}.
 
 allowed_methods(Req, State) ->
     {['POST'], Req, State}.
@@ -51,9 +44,11 @@ process_post(Req, State) ->
     end.
 
 valid_type(<<"actor">>) -> ok;
-valid_type(<<"container">>) -> ok;
-valid_type(<<"group">>) -> ok;
-valid_type(<<"object">>) -> ok.
+valid_type(<<"group">>) -> ok.
+
+normalize_type(<<"actor">>) -> actor;
+normalize_type(<<"group">>) -> group.
+
 
 regex_for(authz_id) ->
     {ok, Regex} = re:compile("^[a-fA-F0-9]{32}$"),
@@ -72,7 +67,7 @@ parse_body(Body) ->
         Ejson = bifrost_wm_util:decode(Body),
         case ej:valid(bulk_spec(), Ejson) of
             ok ->
-                AuthType = binary_to_atom(ej:get({<<"type">>}, Ejson), utf8),
+                AuthType = normalize_type(ej:get({<<"type">>}, Ejson)),
                 Collection = ej:get({<<"collection">>}, Ejson),
                 {AuthType, Collection};
             BadSpec ->

--- a/apps/bifrost/src/bifrost_wm_bulk_delete_resource.erl
+++ b/apps/bifrost/src/bifrost_wm_bulk_delete_resource.erl
@@ -1,0 +1,96 @@
+-module(bifrost_wm_bulk_delete_resource).
+
+-include("bifrost_wm_rest_endpoint.hrl").
+-include_lib("stats_hero/include/stats_hero.hrl").
+
+-mixin([{bifrost_wm_base, [create_path/2]}]).
+
+-export([
+         process_post/2,
+         post_is_create/2
+        ]).
+
+init(Config) ->
+    bifrost_wm_base:init(?MODULE, Config).
+
+post_is_create(Req, State) ->
+    % We're not creating anything (for a change), just processing information, so
+    % we want to return 200's instead of 201's here; also, instead of from_json, we'll
+    % be using process_post below
+    {false, Req, State}.
+
+allowed_methods(Req, State) ->
+    {['POST'], Req, State}.
+
+validate_request(Req, State) ->
+    bifrost_wm_base:validate_requestor(Req, State).
+
+auth_info(_Method) ->
+    ignore.
+
+process_post(Req, State) ->
+    try
+        Body = wrq:req_body(Req),
+        {Type, Collection} = parse_body(Body),
+        case ?SH_TIME(<<"superuser">>, bifrost_db, bulk_delete,
+                      (Collection, Type)) of
+            CountDeleted when is_integer(CountDeleted) ->
+                Req0 = bifrost_wm_util:set_json_body(Req, {[{<<"count">>,
+                                                             CountDeleted}]}),
+                {true, Req0, State};
+            {error, Error} ->
+                bifrost_wm_error:set_db_exception(Req, State, Error)
+        end
+    catch
+        throw:{error, ErrorType} ->
+            {_Return, ErrReq, _State} =
+                bifrost_wm_error:set_malformed_request(Req, State, ErrorType),
+            {{halt, 400}, ErrReq, State};
+        throw:{db_error, ErrorType} ->
+            bifrost_wm_error:set_db_exception(Req, State, ErrorType)
+    end.
+
+valid_type(<<"actor">>) -> ok;
+valid_type(<<"container">>) -> ok;
+valid_type(<<"group">>) -> ok;
+valid_type(<<"object">>) -> ok.
+
+regex_for(authz_id) ->
+    {ok, Regex} = re:compile("^[a-fA-F0-9]{32}$"),
+    {Regex, <<"invalid authz ID, must be 32-digit hex string">>}.
+
+bulk_spec() ->
+    {[
+      {<<"type">>, {fun_match, {fun valid_type/1, string,
+                                <<"invalid authz type, must be 'actor', 'container',"
+                                  " 'group', or 'object'">>}}},
+      {<<"collection">>, {array_map, {string_match, regex_for(authz_id)}}}
+     ]}.
+
+parse_body(Body) ->
+    try
+        Ejson = bifrost_wm_util:decode(Body),
+        case ej:valid(bulk_spec(), Ejson) of
+            ok ->
+                AuthType = binary_to_atom(ej:get({<<"type">>}, Ejson), utf8),
+                Collection = ej:get({<<"collection">>}, Ejson),
+                {AuthType, Collection};
+            BadSpec ->
+                throw(BadSpec)
+        end
+    catch
+        throw:{error, {_, invalid_json}} ->
+            throw({error, invalid_json});
+        throw:{error, {_, truncated_json}} ->
+            throw({error, invalid_json});
+        throw:{ej_invalid, string_match, _, _, _, _, Message} ->
+            throw({error, {ej_invalid, Message}});
+        throw:{ej_invalid, fun_match, _, _, _, _, Message} ->
+            throw({error, {ej_invalid, Message}});
+        throw:{ej_invalid, array_elt, _, _, _, _, Message} ->
+            throw({error, {ej_invalid, Message}});
+        throw:{ej_invalid, missing, Type, _, _, _, _} ->
+            throw({error, {missing, Type}});
+        throw:{ej_invalid, json_type, Type, _, _, _, _} ->
+            throw({error, {json_type, Type}})
+    end.

--- a/apps/bifrost/src/bifrost_wm_bulk_resource.erl
+++ b/apps/bifrost/src/bifrost_wm_bulk_resource.erl
@@ -6,18 +6,11 @@
 -mixin([{bifrost_wm_base, [create_path/2]}]).
 
 -export([
-         process_post/2,
-         post_is_create/2
+         process_post/2
         ]).
 
 init(Config) ->
     bifrost_wm_base:init(?MODULE, Config).
-
-post_is_create(Req, State) ->
-    % We're not creating anything (for a change), just processing information, so
-    % we want to return 200's instead of 201's here; also, instead of from_json, we'll
-    % be using process_post below
-    {false, Req, State}.
 
 allowed_methods(Req, State) ->
     {['POST'], Req, State}.

--- a/apps/bifrost/src/bifrost_wm_bulk_resource.erl
+++ b/apps/bifrost/src/bifrost_wm_bulk_resource.erl
@@ -5,7 +5,10 @@
 
 -mixin([{bifrost_wm_base, [create_path/2]}]).
 
--export([process_post/2]).
+-export([
+         process_post/2,
+         post_is_create/2
+        ]).
 
 init(Config) ->
     bifrost_wm_base:init(?MODULE, Config).
@@ -79,9 +82,7 @@ valid_type(_) -> error.
 
 regex_for(authz_id) ->
     {ok, Regex} = re:compile("^[a-fA-F0-9]{32}$"),
-    {Regex, <<"invalid authz ID, must be 32-digit hex string">>};
-regex_for(_) ->
-    error.
+    {Regex, <<"invalid authz ID, must be 32-digit hex string">>}.
 
 bulk_spec() ->
     {[


### PR DESCRIPTION
Adds the resource "bulk/delete" which accepts post with a request body:
{
  "type" : "(actor|group)",
  "collection": ["authz_ids"]
}

and returns error in the event of a server error and ok with body
{
  "count": num_deleted
}
in the event of success.  Num_deleted may be different than the length of the collection if some authz_ids are missing at time of request.